### PR TITLE
Add quick setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ Please download Sciter dynamic library yourself.
 
 - run `cargo run`
 
+### Automated setup on Debian/Ubuntu
+
+A helper script is available at `scripts/setup_env.sh` which installs
+the required packages, fetches submodules and builds the project.
+Run the script from the repository root:
+
+```sh
+./scripts/setup_env.sh
+```
+
+Any additional arguments are passed directly to `cargo build`.
+
 ## [Build](https://rustdesk.com/docs/en/dev/build/)
 
 ## How to build on Linux

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Simple environment setup script for RustDesk development on Debian/Ubuntu
+set -euo pipefail
+
+# Install required packages
+sudo apt update
+sudo apt install -y zip g++ gcc git curl wget nasm yasm libgtk-3-dev clang \
+  libxcb-randr0-dev libxdo-dev libxfixes-dev libxcb-shape0-dev libxcb-xfixes0-dev \
+  libasound2-dev libpulse-dev cmake make libclang-dev ninja-build \
+  libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libpam0g-dev
+
+# Install Rust toolchain if not present
+if ! command -v cargo >/dev/null; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source "$HOME/.cargo/env"
+fi
+
+# Clone submodules
+git submodule update --init --recursive
+
+# Install vcpkg
+if [ ! -d "$HOME/vcpkg" ]; then
+    git clone https://github.com/microsoft/vcpkg "$HOME/vcpkg"
+    (cd "$HOME/vcpkg" && git checkout 2023.04.15 && ./bootstrap-vcpkg.sh)
+fi
+export VCPKG_ROOT="$HOME/vcpkg"
+"$VCPKG_ROOT"/vcpkg install libvpx libyuv opus aom
+
+# Download sciter library
+mkdir -p target/debug
+if [ ! -f target/debug/libsciter-gtk.so ]; then
+    wget https://raw.githubusercontent.com/c-smile/sciter-sdk/master/bin.lnx/x64/libsciter-gtk.so \
+         -O target/debug/libsciter-gtk.so
+fi
+
+# Build project
+VCPKG_ROOT="$VCPKG_ROOT" cargo build "$@"


### PR DESCRIPTION
## Summary
- add `scripts/setup_env.sh` for Debian/Ubuntu development environment
- document the script in README

## Testing
- `cargo test` *(fails: failed to read libs/hbb_common/Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_b_6841ed92de70832bae15eaec7d4f4b28